### PR TITLE
Remove extensions that we don't use to prevent panics

### DIFF
--- a/markdown/main.go
+++ b/markdown/main.go
@@ -662,15 +662,11 @@ func NewGoldmark() goldmark.Markdown {
 	mr := NewRenderer()
 
 	extensions := []goldmark.Extender{
-		extension.Table,
-		extension.Strikethrough,
-		extension.Linkify,
-		extension.TaskList,
-		extension.DefinitionList,
-		extension.Footnote,
+		extension.Table,         // we need this to enable | tables |
+		extension.Strikethrough, // we need this to enable ~~strike~~
 	}
 	parserOptions := []parser.Option{
-		parser.WithAttribute(),
+		parser.WithAttribute(), // we need this to enable # headers {#custom-ids}
 	}
 
 	gm := goldmark.New(

--- a/markdown/testfiles/reference.same.md
+++ b/markdown/testfiles/reference.same.md
@@ -160,4 +160,6 @@ Useful for writing poems.
 
 [https://path\to\page](https://path\\to\\page)
 
+Links in Markdown are not changed, like http://google.com
+
 Done.


### PR DESCRIPTION
We can remove autolink safely since it just reders it as text.

We do not use footnotes, definitions, task lists.