### PR TITLE
maintain and format attribute lists

### DIFF
--- a/markdownfmt/testfiles/example1.input.md
+++ b/markdownfmt/testfiles/example1.input.md
@@ -34,13 +34,13 @@ defer f.Close() // What if an error occurs here?
 
 // Write something to file... etc.
 ```
-Title
+Title {#title}
 ==
 
 Paragraphs will be also concatenated for clean view.
 However, it might be not easy to edit it via editors, so you can specify text line width to be ensured. It also makes sure words are together,so it will ensure wanted line length as you wish.
 
-Subtitle
+Subtitle {other=attribute class="subhead bold" id=sub}
 ---
 
 How about `this` and other stuff 

--- a/markdownfmt/testfiles/example1.output.md
+++ b/markdownfmt/testfiles/example1.output.md
@@ -33,11 +33,11 @@ defer f.Close() // What if an error occurs here?
 // Write something to file... etc.
 ```
 
-# Title
+# Title {#title}
 
 Paragraphs will be also concatenated for clean view. However, it might be not easy to edit it via editors, so you can specify text line width to be ensured. It also makes sure words are together,so it will ensure wanted line length as you wish.
 
-## Subtitle
+## Subtitle {#sub .subhead .bold other=attribute}
 
 How about `this` and other stuff like *italic*, *underline italic*, **bold**, **bold spaces**.
 

--- a/markdownfmt/testfiles/headers.same.md
+++ b/markdownfmt/testfiles/headers.same.md
@@ -37,3 +37,9 @@ Paragraph
 > ## Header {#custom}
 >
 > ### Header {#custom}
+
+# Header {#custom .withClass}
+
+## Header {#custom .withClass singleTag}
+
+### Header {#custom .withClass singleTag other=opt}


### PR DESCRIPTION
Move id and class to the beginning, then alphabetize remaining.

Fixes #23 