### PR TITLE
Use list start if it was set

### DIFF
--- a/markdown/renderer.go
+++ b/markdown/renderer.go
@@ -326,6 +326,9 @@ func listItemMarkerChars(tnode *ast.ListItem) []byte {
 	parList := tnode.Parent().(*ast.List)
 	if parList.IsOrdered() {
 		cnt := 1
+		if parList.Start != 0 {
+			cnt = parList.Start
+		}
 		s := tnode.PreviousSibling()
 		for s != nil {
 			cnt++


### PR DESCRIPTION
If the list start is set in the AST, start from there instead of always starting from 1.