### PR TITLE
render: Support custom formatters

### DIFF
--- a/markdownfmt/markdownfmt_test.go
+++ b/markdownfmt/markdownfmt_test.go
@@ -137,6 +137,28 @@ func TestDifferent(t *testing.T) {
 	}
 }
 
+func TestCustomCodeFormatter(t *testing.T) {
+	reference, err := ioutil.ReadFile("testfiles/nested-code.same.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	output, err := markdownfmt.Process(
+		"", reference, markdown.WithCodeFormatters(markdown.CodeFormatter{
+			Name: "Makefile",
+			Format: func(b []byte) []byte {
+				return []byte("replaced contents")
+			},
+		}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if want := " replaced contents\n"; !bytes.Contains(output, []byte(want)) {
+		t.Errorf("output does not contain %q:\n%s", want, output)
+	}
+}
+
 // TODO: Factor out.
 func diff(b1, b2 []byte) (data []byte, err error) {
 	f1, err := ioutil.TempFile("", "markdownfmt")


### PR DESCRIPTION
The renderer currently unconditionally reformats Go code samples,
and only Go code samples.

There are a couple issues with this:

- this can lead to inconsistent formatting if some samples
  are fully valid Go code and others aren't
- when desirable, this only works for Go, and nothing else

This proposes a new WithCodeFormatters option for the renderer.
If used, this option replaces the list of code formatters
used by the renderer.

Code formatters are matched by language, optionally with aliases.
By default, only a formatter for "go" (with the alias "Go")
is included -- this matches the prior behavior.

If WithCodeFormatters is called without any arguments,
it disables code formatting completely.
