### PR TITLE
test(markdownfmt): Don't shell out to 'diff'

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/Kunde21/markdownfmt/v2
 
 require (
+	github.com/google/go-cmp v0.5.9
 	github.com/mattn/go-runewidth v0.0.9
 	github.com/pkg/errors v0.9.1
 	github.com/yuin/goldmark v1.3.5

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=


### PR DESCRIPTION
Instead of shelling out to diff to determine if two files are equal,
use [go-cmp].
This is the recommended approach per [Go Test Comments].

[go-cmp]: https://pkg.go.dev/github.com/google/go-cmp/cmp
[Go Test Comments]: https://github.com/golang/go/wiki/TestComments#equality-comparison-and-diffs

Sample output after deleting a line from example1.output.md.

```
--- FAIL: TestDifferent (0.00s)
    --- FAIL: TestDifferent/testfiles/example1.input.md (0.00s)
        markdownfmt_test.go:117: Difference in testfiles/example1.input.md of 11 lines:
              (
                """
                ... // 13 identical lines
              
                ```go
            +   f, err := os.Open(something)
                if err != nil {
                        // handle..
                ... // 27 identical lines
                """
              )
```
