### PR TITLE
go.mod: Raise to Go 1.18, use Go 1.18 in CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,13 +10,17 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: ["1.18.x", "1.19.x"]
+
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Go
+    - name: Set up Go ${{ matrix.go }}
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ${{ matrix.go }}
 
     - name: Build
       run: go build -v ./...

--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,4 @@ require (
 	github.com/yuin/goldmark v1.3.5
 )
 
-go 1.13
+go 1.18


### PR DESCRIPTION
This updates the `go` directive in go.mod to Go 1.18,
and also updates CI to test against both, Go 1.18 and 1.19.

Per the [Go release policy], only the current
and previous minor releases are supported.
So with Go 1.19 out, only 1.18 and 1.19 receive bug and security fixes.

[Go release policy]: https://go.dev/doc/devel/release#policy
