### PR TITLE
doc(markdown): Update package-level docstring

### DIFF
--- a/markdown/doc.go
+++ b/markdown/doc.go
@@ -1,0 +1,2 @@
+// Package markdown renders the given goldmark AST to Markdown.
+package markdown

--- a/markdown/renderer.go
+++ b/markdown/renderer.go
@@ -1,4 +1,3 @@
-// Package renderer renders the given AST to certain formats.
 package markdown
 
 import (


### PR DESCRIPTION
The package-level godoc for the markdown package calls it "renderer,"
and references "certain formats."

Update to use the package's actual name, and that it renders Markdown.
