### PR TITLE
pkg/errors => fmt.Errorf

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/mattn/go-runewidth v0.0.9
 	github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e
-	github.com/pkg/errors v0.9.1
 	github.com/yuin/goldmark v1.3.5
 )
 

--- a/go.sum
+++ b/go.sum
@@ -4,7 +4,5 @@ github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/Qd
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e h1:aoZm08cpOy4WuID//EZDgcC4zIxODThtZNPirFr42+A=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/yuin/goldmark v1.3.5 h1:dPmz1Snjq0kmkz159iL7S6WzdahUTHnHB5M56WFVifs=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=

--- a/markdown/renderer.go
+++ b/markdown/renderer.go
@@ -8,7 +8,6 @@ import (
 	"unicode/utf8"
 	"unsafe"
 
-	"github.com/pkg/errors"
 	"github.com/yuin/goldmark/ast"
 	extAST "github.com/yuin/goldmark/extension/ast"
 	"github.com/yuin/goldmark/renderer"
@@ -341,7 +340,7 @@ func (r *render) renderNode(node ast.Node, entering bool) (ast.WalkStatus, error
 		// Render it straight away. No nested headings are supported and we expect
 		// headings to have limited content, so limit WALK.
 		if err := r.renderHeading(tnode); err != nil {
-			return ast.WalkStop, errors.Wrap(err, "rendering heading")
+			return ast.WalkStop, fmt.Errorf("rendering heading: %w", err)
 		}
 		return ast.WalkSkipChildren, nil
 	case *ast.HTMLBlock:
@@ -437,13 +436,13 @@ func (r *render) renderNode(node ast.Node, entering bool) (ast.WalkStatus, error
 		// Render it straight away. No nested tables are supported and we expect
 		// tables to have limited content, so limit WALK.
 		if err := r.renderTable(tnode); err != nil {
-			return ast.WalkStop, errors.Wrap(err, "rendering table")
+			return ast.WalkStop, fmt.Errorf("rendering table: %w", err)
 		}
 		return ast.WalkSkipChildren, nil
 	case *extAST.TableRow, *extAST.TableHeader:
-		return ast.WalkStop, errors.Errorf("%v element detected, but table should be rendered in renderTable instead", tnode.Kind().String())
+		return ast.WalkStop, fmt.Errorf("%v element detected, but table should be rendered in renderTable instead", tnode.Kind())
 	default:
-		return ast.WalkStop, errors.Errorf("detected unexpected tree type %s", tnode.Kind().String())
+		return ast.WalkStop, fmt.Errorf("detected unexpected tree type %v", tnode.Kind())
 	}
 	return ast.WalkContinue, nil
 }

--- a/markdown/renderer_table.go
+++ b/markdown/renderer_table.go
@@ -2,9 +2,9 @@ package markdown
 
 import (
 	"bytes"
+	"fmt"
 
 	"github.com/mattn/go-runewidth"
-	"github.com/pkg/errors"
 	"github.com/yuin/goldmark/ast"
 	extAST "github.com/yuin/goldmark/extension/ast"
 )
@@ -45,7 +45,7 @@ func (r *render) renderTable(node *extAST.Table) error {
 					return ast.WalkSkipChildren, nil
 				}
 			default:
-				return ast.WalkStop, errors.Errorf("detected unexpected tree type %s", tnode.Kind().String())
+				return ast.WalkStop, fmt.Errorf("detected unexpected tree type %v", tnode.Kind())
 			}
 			return ast.WalkContinue, nil
 		}); err != nil {
@@ -129,7 +129,7 @@ func (r *render) renderTable(node *extAST.Table) error {
 				colIndex++
 				return ast.WalkSkipChildren, nil
 			default:
-				return ast.WalkStop, errors.Errorf("detected unexpected tree type %s", tnode.Kind().String())
+				return ast.WalkStop, fmt.Errorf("detected unexpected tree type %v", tnode.Kind())
 			}
 			return ast.WalkContinue, nil
 		}); err != nil {


### PR DESCRIPTION
Drop use of `pkg/errors.Wrap` and `pkg/errors.Errorf`
in favor of `fmt.Errorf`.

Minor optimization:
There were cases where Errorf was used with `x.String()`
as an argument.
This is unnecessary because `%v` will default to calling String
for types that implement fmt.Stringer.

Resolves #49
