### PR TITLE
godoc: All exported entities

### DIFF
--- a/markdown/renderer.go
+++ b/markdown/renderer.go
@@ -42,18 +42,24 @@ type Renderer struct {
 	formatters map[string]func([]byte) []byte
 }
 
+// AddOptions does not do anything.
+// You probably want to use [Renderer.AddMarkdownOptions].
 func (mr *Renderer) AddOptions(...renderer.Option) {
 	// goldmark weirdness, just ignore (called with just HTML options...)
 }
 
+// AddMarkdownOptions modifies the Renderer with the given options.
 func (mr *Renderer) AddMarkdownOptions(opts ...Option) {
 	for _, o := range opts {
 		o(mr)
 	}
 }
 
+// Option customizes the behavior of the markdown renderer.
 type Option func(r *Renderer)
 
+// WithUnderlineHeadings configures the renderer to use
+// Setext-style headers (=== and ---).
 func WithUnderlineHeadings() Option {
 	return func(r *Renderer) {
 		r.underlineHeadings = true
@@ -154,6 +160,19 @@ func DefaultCodeFormatters() []CodeFormatter {
 	}
 }
 
+// NewRenderer builds a new Markdown renderer with default settings.
+// To use this with goldmark.Markdown, use the goldmark.WithRenderer option.
+//
+//	r := markdown.NewRenderer()
+//	md := goldmark.New(goldmark.WithRenderer(r))
+//	md.Convert(src, w)
+//
+// Alternatively, you can call [Renderer.Render] directly.
+//
+//	r := markdown.NewRenderer()
+//	r.Render(w, src, node)
+//
+// Use [Renderer.AddMarkdownOptions] to customize the output of the renderer.
 func NewRenderer() *Renderer {
 	r := &Renderer{
 		emphToken: []byte{'*'},
@@ -192,7 +211,9 @@ func (mr *Renderer) newRender(w io.Writer, source []byte) *render {
 	}
 }
 
-// Render renders the given AST node to the given buffer with the given Renderer.
+// Render renders the given AST node to the given writer,
+// given the original source from which the node was parsed.
+//
 // NOTE: This is the entry point used by Goldmark.
 func (mr *Renderer) Render(w io.Writer, source []byte, node ast.Node) error {
 	// Perform DFS.

--- a/markdownfmt/markdownfmt.go
+++ b/markdownfmt/markdownfmt.go
@@ -10,11 +10,14 @@ import (
 	"github.com/yuin/goldmark/parser"
 )
 
-// TODO(karel): unused, can we delete?
+// NewParser builds a new goldmark parser
+// capable of generating ASTs that markdownfmt can render.
 func NewParser() parser.Parser {
 	return NewGoldmark().Parser()
 }
 
+// NewGoldmark builds a new [goldmark.Markdown] object
+// capable of reformatting GitHub Formatted Markdown.
 func NewGoldmark(opts ...markdown.Option) goldmark.Markdown {
 	mr := markdown.NewRenderer()
 	mr.AddMarkdownOptions(opts...)


### PR DESCRIPTION
A couple exported functions and types were not documented.
This adds some basic godoc to them.

Note that there was a comment on markdownfmt.NewParser
about the possibility of deleting it.
I've deleted that comment because deleting NewParser now
would be a breaking change requiring a v3.
That's not out of the question,
but it seems like a minor thing to cut a v3 over.
