### PR TITLE
perf: Don't Sprintf for ordered lists

### DIFF
--- a/markdown/renderer.go
+++ b/markdown/renderer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"go/format"
 	"io"
+	"strconv"
 	"unicode/utf8"
 	"unsafe"
 
@@ -494,7 +495,7 @@ func listItemMarkerChars(tnode *ast.ListItem) []byte {
 			cnt++
 			s = s.PreviousSibling()
 		}
-		return []byte(fmt.Sprintf("%d%c ", cnt, parList.Marker))
+		return append(strconv.AppendInt(nil, int64(cnt), 10), parList.Marker, ' ')
 	}
 	return []byte{parList.Marker, spaceChar[0]}
 }


### PR DESCRIPTION
In order to generate the prefix for ordered lists,
listItemMarkerChars currently uses `fmt.Sprintf`.

    fmt.Sprintf("%d%c ", cnt, parList.Marker)

We can make this significantly cheaper
by using `strconv.AppendInt` to convert `cnt` to a `[]byte`,
and appending to that byte slice instead.

# Results

Cherry-picking the benchmark from #53,
we get the following results with this change:

```
name                                   old time/op    new time/op    delta
Render/example1.input.md-2               34.2µs ± 0%    33.0µs ± 2%   -3.31%  (p=0.008 n=5+5)
Render/headers.same.md-2                 37.2µs ± 2%    37.4µs ± 4%     ~     (p=0.841 n=5+5)
Render/html.input.md-2                   10.9µs ± 4%    10.8µs ± 1%     ~     (p=0.690 n=5+5)
Render/lists.input.md-2                   139µs ± 3%      91µs ± 1%  -34.64%  (p=0.008 n=5+5)
Render/lists.same.md-2                   47.4µs ± 1%    34.2µs ± 0%  -27.82%  (p=0.008 n=5+5)
Render/nested-code.same.md-2             3.34µs ±26%    3.08µs ± 3%     ~     (p=0.151 n=5+5)
Render/reference.same.md-2                209µs ±27%     192µs ± 5%     ~     (p=0.310 n=5+5)
Render/successive.input.md-2             9.50µs ± 1%    9.41µs ± 1%     ~     (p=0.151 n=5+5)
Render/things-inside-blocks.same.md-2     129µs ± 5%     119µs ± 2%   -8.11%  (p=0.008 n=5+5)
Render/widechar.input.md-2               4.65µs ± 2%    5.05µs ±10%     ~     (p=0.095 n=5+5)

name                                   old alloc/op   new alloc/op   delta
Render/example1.input.md-2               4.39kB ± 0%    4.36kB ± 0%   -0.73%  (p=0.008 n=5+5)
Render/headers.same.md-2                 9.27kB ± 0%    9.27kB ± 0%     ~     (all equal)
Render/html.input.md-2                   2.15kB ± 0%    2.15kB ± 0%     ~     (all equal)
Render/lists.input.md-2                  6.00kB ± 0%    4.82kB ± 0%  -19.61%  (p=0.008 n=5+5)
Render/lists.same.md-2                   2.26kB ± 0%    1.95kB ± 0%  -13.78%  (p=0.008 n=5+5)
Render/nested-code.same.md-2               432B ± 0%      432B ± 0%     ~     (all equal)
Render/reference.same.md-2               25.6kB ± 0%    25.4kB ± 0%   -0.63%  (p=0.008 n=5+5)
Render/successive.input.md-2               520B ± 0%      520B ± 0%     ~     (all equal)
Render/things-inside-blocks.same.md-2    18.3kB ± 0%    18.2kB ± 0%   -0.87%  (p=0.008 n=5+5)
Render/widechar.input.md-2               1.24kB ± 0%    1.24kB ± 0%     ~     (all equal)

name                                   old allocs/op  new allocs/op  delta
Render/example1.input.md-2                  152 ± 0%       148 ± 0%   -2.63%  (p=0.008 n=5+5)
Render/headers.same.md-2                    217 ± 0%       217 ± 0%     ~     (all equal)
Render/html.input.md-2                     30.0 ± 0%      30.0 ± 0%     ~     (all equal)
Render/lists.input.md-2                     749 ± 0%       547 ± 0%  -26.97%  (p=0.008 n=5+5)
Render/lists.same.md-2                      264 ± 0%       210 ± 0%  -20.45%  (p=0.008 n=5+5)
Render/nested-code.same.md-2               14.0 ± 0%      14.0 ± 0%     ~     (all equal)
Render/reference.same.md-2                  932 ± 0%       908 ± 0%   -2.58%  (p=0.008 n=5+5)
Render/successive.input.md-2               39.0 ± 0%      39.0 ± 0%     ~     (all equal)
Render/things-inside-blocks.same.md-2       658 ± 0%       632 ± 0%   -3.95%  (p=0.008 n=5+5)
Render/widechar.input.md-2                 29.0 ± 0%      29.0 ± 0%     ~     (all equal)
```

Since this change affects ast.ListItem only,
that's where the bulk of the performance improvements are.
