### PR TITLE
main: Don't store exitCode globally

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestStdinStdout(t *testing.T) {
+	const (
+		input  = "# hello\nworld"
+		output = "# hello\n\nworld\n"
+	)
+
+	var stdout, stderr bytes.Buffer
+	cmd := mainCmd{
+		Stdin:  strings.NewReader(input),
+		Stdout: &stdout,
+		Stderr: &stderr,
+	}
+	cmd.Run(nil /* args */)
+	if want, got := 0, cmd.exitCode; want != got {
+		t.Fatalf("unexpected exit code %v, want %v", got, want)
+	}
+
+	if stderr.Len() > 0 {
+		t.Errorf("unexpected stderr: %v", stderr.String())
+	}
+
+	gotOutput := stdout.String()
+	if diff := cmp.Diff(output, gotOutput); len(diff) > 0 {
+		t.Errorf("unexpected output %q, want %q\ndiff: %v", gotOutput, output, diff)
+	}
+}
+
+func TestFileDoesNotExist(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	cmd := mainCmd{
+		Stdin:  new(bytes.Buffer), // empty stdin
+		Stdout: &stdout,
+		Stderr: &stderr,
+	}
+	cmd.Run([]string{"file-does-not-exist.md"})
+
+	if want, got := 2, cmd.exitCode; want != got {
+		t.Errorf("unexpected exit code %v, want %v", got, want)
+	}
+
+	gotStderr := stderr.String()
+	wantStderr := "file-does-not-exist.md: no such file"
+	if !strings.Contains(gotStderr, wantStderr) {
+		t.Errorf("unexpected stderr %q, should contain %q", gotStderr, wantStderr)
+	}
+}


### PR DESCRIPTION
This makes a minor refactor to main
to avoid use of a global exit code variable.

Instead, we declare a mainCmd struct
that stores global program state like exitCode.

This also allows us to change the definition of
stdin, stdout, and stderr,
so that tests can provide varying values.

This contains no logic changes.
All changes are mechanical. Roughly:

- Turn `report(error)` into a method
  that manipulates state on mainCmd.
- Change every function that calls `report` into a method,
  and every function that calls *that* as well.
- Instead of `flag.Parse()`, which operates on `os.Args`,
  call `flag.CommandLine.Parse` with a specific list of arguments.
- Delete `exitCode` variable.
