### PR TITLE
Don't reformat code blocks by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - Support raw HTML blocks.
 - Add `WithSoftWraps` to retain soft line breaks.
-- Add `WithCodeFormatters` to supply custom formatters for code blocks.
+- Add `WithCodeFormatters` to supply custom formatters for code blocks, and a `GoCodeFormatter` built-in formatter.
 - Add `WithEmphasisToken` and `WithStrongToken` to change the tokens used for bold and italic text.
+- `markdownfmt` CLI: Add `-gofmt` flag to enable reformatting of Go source code.
 
 ### Changed
-- The `markdownfmt` CLI no longer shells out to `diff`.
+- Don't modify code inside fenced code by default. Supply the `WithCodeFormatters` option to the `Renderer` to enable reformatting of source code.
+- `markdownfmt` CLI: Don't shell out to `diff` in `-d` mode.
+- `markdownfmt` CLI: Don't reformat Go source code inside fenced code blocks. Opt into this functionality with the `-gofmt` flag.
 
 ### Fixed
 - Fix formatting of whitespace in code blocks.

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ func (cmd *mainCmd) registerFlags(flag *flag.FlagSet) {
 	flag.BoolVar(&cmd.diff, "d", false, "display diffs instead of rewriting files")
 	flag.BoolVar(&cmd.underlineHeadings, "u", false, "write underline headings instead of hashes for levels 1 and 2")
 	flag.BoolVar(&cmd.softWraps, "soft-wraps", false, "wrap lines even on soft line breaks")
+	flag.BoolVar(&cmd.gofmt, "gofmt", false, "reformat Go source inside fenced code blocks")
 }
 
 func (cmd *mainCmd) report(err error) {
@@ -57,6 +58,9 @@ func (cmd *mainCmd) processFile(filename string, in io.Reader, out io.Writer) er
 	}
 	if cmd.softWraps {
 		opts = append(opts, markdown.WithSoftWraps())
+	}
+	if cmd.gofmt {
+		opts = append(opts, markdown.WithCodeFormatters(markdown.GoCodeFormatter))
 	}
 	res, err := markdownfmt.Process(filename, src, opts...)
 	if err != nil {
@@ -138,6 +142,7 @@ type mainCmd struct {
 	// Output manipulation.
 	underlineHeadings bool
 	softWraps         bool
+	gofmt             bool
 }
 
 func (cmd *mainCmd) parseArgs(args []string) ([]string, error) {

--- a/markdown/code_formatter_test.go
+++ b/markdown/code_formatter_test.go
@@ -1,0 +1,40 @@
+package markdown
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestFormatGo(t *testing.T) {
+	tests := []struct {
+		desc string
+		give string
+		want string
+	}{
+		{
+			desc: "empty",
+			give: "",
+			want: "",
+		},
+		{
+			desc: "valid code",
+			give: "func main(){fmt.Println(msg)\n}",
+			want: "func main() {\n\tfmt.Println(msg)\n}",
+		},
+		{
+			desc: "invalid code",
+			give: "func main(){",
+			want: "func main(){",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			got := formatGo([]byte(tt.give))
+			if diff := cmp.Diff(tt.want, string(got)); len(diff) > 0 {
+				t.Errorf("formatGo(%q) = %q, want %q\ndiff %v", tt.give, string(got), tt.want, diff)
+			}
+		})
+	}
+}

--- a/markdownfmt/markdownfmt_test.go
+++ b/markdownfmt/markdownfmt_test.go
@@ -122,6 +122,38 @@ func TestDifferent(t *testing.T) {
 	}
 }
 
+func TestGoCodeFormatter(t *testing.T) {
+	matches, err := filepath.Glob("testfiles/*.gofmt-input.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range matches {
+		t.Run(f, func(t *testing.T) {
+			input, err := os.ReadFile(f)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			expOutput, err := os.ReadFile(strings.ReplaceAll(f, ".gofmt-input.md", ".gofmt-output.md"))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			output, err := markdownfmt.Process("", input, markdown.WithCodeFormatters(markdown.GoCodeFormatter))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			diff := diff(expOutput, output)
+			if len(diff) != 0 {
+				fmt.Println("----\n", string(output), "\n---")
+
+				t.Errorf("Difference in %s of %d lines:\n%s", f, strings.Count(diff, "\n"), diff)
+			}
+		})
+	}
+}
+
 func TestCustomCodeFormatter(t *testing.T) {
 	reference, err := os.ReadFile("testfiles/nested-code.same.md")
 	if err != nil {

--- a/markdownfmt/testfiles/example.gofmt-input.md
+++ b/markdownfmt/testfiles/example.gofmt-input.md
@@ -1,0 +1,23 @@
+Valid but incorrectly formatted code:
+```go
+f, err := os.Open(something)
+    if err != nil {
+    // handle..
+}
+defer f.Close() // What if an error occurs here?
+
+// Write something to file... etc.
+```
+
+Invalid code:
+
+```go
+// Non parsable go code should be handled, but will be not go fmt-ed.
+f, err := os.Open(...)
+    if err != nil {
+    // handle..
+}
+defer f.Close() // What if an error occurs here?
+
+// Write something to file... etc.
+```

--- a/markdownfmt/testfiles/example.gofmt-output.md
+++ b/markdownfmt/testfiles/example.gofmt-output.md
@@ -1,0 +1,24 @@
+Valid but incorrectly formatted code:
+
+```go
+f, err := os.Open(something)
+if err != nil {
+	// handle..
+}
+defer f.Close() // What if an error occurs here?
+
+// Write something to file... etc.
+```
+
+Invalid code:
+
+```go
+// Non parsable go code should be handled, but will be not go fmt-ed.
+f, err := os.Open(...)
+    if err != nil {
+    // handle..
+}
+defer f.Close() // What if an error occurs here?
+
+// Write something to file... etc.
+```

--- a/markdownfmt/testfiles/example1.input.md
+++ b/markdownfmt/testfiles/example1.input.md
@@ -24,16 +24,7 @@ defer f.Close() // What if an error occurs here?
 
 // Write something to file... etc.
 ```
-```go
-// Non parsable go code should be handled, but will be not go fmt-ed.
-f, err := os.Open(...)
-    if err != nil {
-    // handle..
-}
-defer f.Close() // What if an error occurs here?
 
-// Write something to file... etc.
-```
 Title {#title}
 ==
 

--- a/markdownfmt/testfiles/example1.output.md
+++ b/markdownfmt/testfiles/example1.output.md
@@ -14,17 +14,6 @@ Is really new.
 
 ```go
 f, err := os.Open(something)
-if err != nil {
-	// handle..
-}
-defer f.Close() // What if an error occurs here?
-
-// Write something to file... etc.
-```
-
-```go
-// Non parsable go code should be handled, but will be not go fmt-ed.
-f, err := os.Open(...)
     if err != nil {
     // handle..
 }


### PR DESCRIPTION
This is a follow up to #38 where @karelbilek brought up that
we shouldn't reformat source code blocks by default at all.

With this change, fenced code blocks tagged with `Go` or `go`
will no longer be formatted with `gofmt` by default.
Users are expected to opt-into this functionality.

When using markdownfmt as a library,
users can opt-in by adding the following option.

    WithCodeFormatters(GoCodeFormatter)

When using markdownfmt as a binary,
users can opt-in by adding the following flag:

    -gofmt

For integration tests,
I changed example1.input/output to have incorrectly formatted Go code,
and added separate gofmt-input/output files to test behavior
with the GoCodeFormatter enabled.

Resolves #46
