### PR TITLE
Flip to v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # markdownfmt
 
-[![Build Status](https://github.com/Kunde21/markdownfmt/actions/workflows/go.yml/badge.svg?query=branch%3Amaster)](https://github.com/Kunde21/markdownfmt/actions/workflows/go.yml?query=branch%3Amaster) [![Go Reference](https://pkg.go.dev/badge/github.com/Kunde21/markdownfmt/v2.svg)](https://pkg.go.dev/github.com/Kunde21/markdownfmt/v2)
+[![Build Status](https://github.com/Kunde21/markdownfmt/actions/workflows/go.yml/badge.svg?query=branch%3Amaster)](https://github.com/Kunde21/markdownfmt/actions/workflows/go.yml?query=branch%3Amaster) [![Go Reference](https://pkg.go.dev/badge/github.com/Kunde21/markdownfmt/v3.svg)](https://pkg.go.dev/github.com/Kunde21/markdownfmt/v3)
 
 markdownfmt is a CLI that reformats Markdown files (like `gofmt` but for Markdown) and a library that you can use to generate well-formed Markdown files.
 
@@ -15,13 +15,13 @@ markdownfmt is a CLI that reformats Markdown files (like `gofmt` but for Markdow
 ### CLI
 
 ```bash
-go install github.com/Kunde21/markdownfmt/v2@latest
+go install github.com/Kunde21/markdownfmt/v3@latest
 ```
 
 ### Library
 
 ```bash
-go get github.com/Kunde21/markdownfmt/v2@latest
+go get github.com/Kunde21/markdownfmt/v3@latest
 ```
 
 ## Usage

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Kunde21/markdownfmt/v2
+module github.com/Kunde21/markdownfmt/v3
 
 require (
 	github.com/mattn/go-runewidth v0.0.9

--- a/main.go
+++ b/main.go
@@ -12,8 +12,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/Kunde21/markdownfmt/v2/markdown"
-	"github.com/Kunde21/markdownfmt/v2/markdownfmt"
+	"github.com/Kunde21/markdownfmt/v3/markdown"
+	"github.com/Kunde21/markdownfmt/v3/markdownfmt"
 	"github.com/pkg/diff"
 )
 

--- a/markdownfmt/markdownfmt.go
+++ b/markdownfmt/markdownfmt.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"os"
 
-	"github.com/Kunde21/markdownfmt/v2/markdown"
+	"github.com/Kunde21/markdownfmt/v3/markdown"
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/extension"
 	"github.com/yuin/goldmark/parser"

--- a/markdownfmt/markdownfmt_test.go
+++ b/markdownfmt/markdownfmt_test.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/Kunde21/markdownfmt/v2/markdown"
-	"github.com/Kunde21/markdownfmt/v2/markdownfmt"
+	"github.com/Kunde21/markdownfmt/v3/markdown"
+	"github.com/Kunde21/markdownfmt/v3/markdownfmt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/yuin/goldmark/text"


### PR DESCRIPTION
This changes the import path for the module to use a v3 suffix
since we've made a breaking change (#56) and plan more.

Refs #59
