### PR TITLE
Compile with Go 1.17

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.18.x", "1.19.x"]
+        go: ["1.17.x", "1.18.x", "1.19.x"]
         include:
         - go: 1.19.x
           os: "ubuntu-latest"

--- a/markdown/renderer.go
+++ b/markdown/renderer.go
@@ -98,7 +98,9 @@ func WithSoftWraps() Option {
 // Defaults to '*'.
 func WithEmphasisToken(c rune) Option {
 	return optionFunc(func(r *Renderer) {
-		r.emphToken = utf8.AppendRune(nil, c)
+		buf := make([]byte, 4) // enough to encode any utf8 rune
+		n := utf8.EncodeRune(buf, c)
+		r.emphToken = buf[:n]
 	})
 }
 

--- a/markdown/renderer_test.go
+++ b/markdown/renderer_test.go
@@ -28,39 +28,3 @@ func TestWriteClean(t *testing.T) {
 		})
 	}
 }
-
-// FuzzWriteClean verifies parity between
-// cleanWithoutTrim and the new writeClean function.
-func FuzzWriteClean(f *testing.F) {
-	f.Add("foo    bar")
-	f.Add("    ")
-	f.Add("foo\n\t\r\nbar")
-	f.Add("foo     ")
-	f.Add("    foo")
-
-	f.Fuzz(func(t *testing.T, s string) {
-		want := string(cleanWithoutTrim([]byte(s)))
-
-		var buff bytes.Buffer
-		require.NoError(t, writeClean(&buff, []byte(s)))
-		assert.Equal(t, want, buff.String())
-	})
-}
-
-// cleanWithoutTrim is an oler version of writeClean
-// retained in tests to verify parity of the new implementation.
-func cleanWithoutTrim(b []byte) []byte {
-	var ret []byte
-	var p byte
-	for i := 0; i < len(b); i++ {
-		q := b[i]
-		if q == '\n' || q == '\r' || q == '\t' {
-			q = ' '
-		}
-		if q != ' ' || p != ' ' {
-			ret = append(ret, q)
-			p = q
-		}
-	}
-	return ret
-}

--- a/markdown/write_clean_fuzz_test.go
+++ b/markdown/write_clean_fuzz_test.go
@@ -1,0 +1,48 @@
+//go:build go1.18
+// +build go1.18
+
+package markdown
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// FuzzWriteClean verifies parity between
+// cleanWithoutTrim and the new writeClean function.
+func FuzzWriteClean(f *testing.F) {
+	f.Add("foo    bar")
+	f.Add("    ")
+	f.Add("foo\n\t\r\nbar")
+	f.Add("foo     ")
+	f.Add("    foo")
+
+	f.Fuzz(func(t *testing.T, s string) {
+		want := string(cleanWithoutTrim([]byte(s)))
+
+		var buff bytes.Buffer
+		require.NoError(t, writeClean(&buff, []byte(s)))
+		assert.Equal(t, want, buff.String())
+	})
+}
+
+// cleanWithoutTrim is an oler version of writeClean
+// retained in tests to verify parity of the new implementation.
+func cleanWithoutTrim(b []byte) []byte {
+	var ret []byte
+	var p byte
+	for i := 0; i < len(b); i++ {
+		q := b[i]
+		if q == '\n' || q == '\r' || q == '\t' {
+			q = ' '
+		}
+		if q != ' ' || p != ' ' {
+			ret = append(ret, q)
+			p = q
+		}
+	}
+	return ret
+}


### PR DESCRIPTION
Go 1.17 is *technically* no longer supported;
upstream Go will not make any fixes to it.

However, as long as supporting it isn't too difficult,
it's not a bad idea to keep the library compiling and running with it.

When we need a feature from 1.18/1.19 that justifies dropping support,
we should feel free to do so.

Refs #69
(Even if that option was added, we would do it only to the v3 version.)
