### PR TITLE
lists: Add opt-in for indenting nested items 4 spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+- markdown: Add `WithListIndentStyle` option to control how blocks inside list items are indented.
+- cli: Add `-list-indent-style` flag to control this option from the CLI.
+
 ## v3.0.0 - 2022-12-14
 
 This is a new major release. You can install it using the module path: github.com/Kunde21/markdownfmt/v3.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ usage: markdownfmt [flags] [path ...]
   -gofmt
         reformat Go source inside fenced code blocks
   -l    list files whose formatting differs from markdownfmt's
+  -list-indent-style value
+        style for indenting items inside lists ("aligned" or "uniform")
   -soft-wraps
         wrap lines even on soft line breaks
   -u    write underline headings instead of hashes for levels 1 and 2

--- a/markdown/list_indent_test.go
+++ b/markdown/list_indent_test.go
@@ -1,0 +1,205 @@
+package markdown
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/text"
+)
+
+func TestListIndentStyle_Aligned(t *testing.T) {
+	renderer := NewRenderer()
+	renderer.AddOptions(WithListIndentStyle(ListIndentAligned))
+
+	tests := []struct {
+		desc string
+		give string
+		want string
+	}{
+		{
+			desc: "no nest",
+			give: "- foo\n",
+			want: "- foo\n",
+		},
+		{
+			desc: "multiple paragraphs",
+			give: joinLines(
+				"- foo",
+				"",
+				"    bar",
+			),
+			want: joinLines(
+				"- foo",
+				"",
+				"  bar",
+			),
+		},
+		{
+			desc: "nested code",
+			give: joinLines(
+				"- foo",
+				"",
+				"    ```go",
+				"    func main()",
+				"    ```",
+			),
+			want: joinLines(
+				"- foo",
+				"",
+				"  ```go",
+				"  func main()",
+				"  ```",
+			),
+		},
+		{
+			desc: "nested list",
+			give: joinLines(
+				"- foo",
+				"",
+				"    - bar",
+				"    - baz",
+				"",
+				"- qux",
+			),
+			want: joinLines(
+				"- foo",
+				"",
+				"  - bar",
+				"  - baz",
+				"",
+				"- qux",
+			),
+		},
+		{
+			desc: "long number",
+			give: joinLines(
+				"123. foo",
+				"",
+				"      bar",
+			),
+			want: joinLines(
+				"123. foo",
+				"",
+				"     bar",
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			src := []byte(tt.give)
+			node := goldmark.DefaultParser().Parse(text.NewReader(src))
+
+			var buff bytes.Buffer
+			require.NoError(t, renderer.Render(&buff, src, node))
+			got := buff.String()
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestListIndentStyle_Uniform(t *testing.T) {
+	renderer := NewRenderer()
+	renderer.AddOptions(WithListIndentStyle(ListIndentUniform))
+
+	tests := []struct {
+		desc string
+		give string
+		want string
+	}{
+		{
+			desc: "no nest",
+			give: "- foo\n",
+			want: "- foo\n",
+		},
+		{
+			desc: "multiple paragraphs",
+			give: joinLines(
+				"- foo",
+				"",
+				"  bar",
+			),
+			want: joinLines(
+				"- foo",
+				"",
+				"    bar",
+			),
+		},
+		{
+			desc: "nested code",
+			give: joinLines(
+				"- foo",
+				"",
+				"  ```go",
+				"  func main()",
+				"  ```",
+			),
+			want: joinLines(
+				"- foo",
+				"",
+				"    ```go",
+				"    func main()",
+				"    ```",
+			),
+		},
+		{
+			desc: "nested list",
+			give: joinLines(
+				"- foo",
+				"",
+				"  - bar",
+				"  - baz",
+				"",
+				"- qux",
+			),
+			want: joinLines(
+				"- foo",
+				"",
+				"    - bar",
+				"    - baz",
+				"",
+				"- qux",
+			),
+		},
+		{
+			desc: "long number",
+			give: joinLines(
+				"123. foo",
+				"",
+				"     bar",
+			),
+			want: joinLines(
+				"123. foo",
+				"",
+				"     bar",
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			src := []byte(tt.give)
+			node := goldmark.DefaultParser().Parse(text.NewReader(src))
+
+			var buff bytes.Buffer
+			require.NoError(t, renderer.Render(&buff, src, node))
+			got := buff.String()
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// Joins one or more lines, ending with a trailing newline if absent.
+func joinLines(lines ...string) string {
+	s := strings.Join(lines, "\n")
+	if !strings.HasSuffix(s, "\n") {
+		s += "\n"
+	}
+	return s
+}

--- a/testdata/example1.list-uniform-input.md
+++ b/testdata/example1.list-uniform-input.md
@@ -1,0 +1,7 @@
+1.  Item one.
+1. Item TWO.
+
+- [x] foo
+    - [ ] bar
+    - [X] baz
+- [ ] bim

--- a/testdata/example1.list-uniform-output.md
+++ b/testdata/example1.list-uniform-output.md
@@ -1,0 +1,7 @@
+1. Item one.
+2. Item TWO.
+
+- [X] foo
+    - [ ] bar
+    - [X] baz
+- [ ] bim

--- a/testdata/lists.list-uniform-input.md
+++ b/testdata/lists.list-uniform-input.md
@@ -1,0 +1,127 @@
+Tight:
+
+1. First
+2. Second
+3. third
+
+Tight, collapsed line:
+
+1. A paragraph
+   with two lines.
+2. Second
+3. third
+
+Tight, uncollapsed line (notice spaces on end of 1):
+
+1. A paragraph  
+   with two lines.
+2. Second
+3. third
+
+
+Untight:
+
+1. First
+
+2. Second
+
+3. third
+
+Untight, collapsed line:
+
+1. A paragraph  
+   with two lines
+
+2. Second
+
+3. third
+
+Untight, uncollapsed line:
+
+1. A paragraph  
+   with two lines
+
+2. Second
+
+3. third
+
+Nested tight:
+
+1.   tight
+     1.   one
+     2.   two
+     3.   three
+2. tight
+   1. one
+   2. two
+   3. three
+
+Nested tight 3:
+
+1. tight
+   1. one
+      - two
+   2. three
+2. tight
+   1. one
+      - two
+   2. three
+
+Nested:
+
+1. tight
+   1. one
+   2. two
+   3. three
+2. untight
+   1. one
+
+   2. two
+   
+   3. three
+2. untight with space
+   
+    1. one
+
+    2. two
+
+    3. three
+3. more nested
+   1. baz
+      - inside
+4. more nested
+   - coffee
+      - beer
+
+4. 4
+5. 5
+6. 6
+7. 7
+8. 8
+9.    9
+10. 10
+11. 11
+    - now 
+    - I 
+12.   might
+      1.  need
+      2.   more
+      3.  spaces for nesting
+
+Spacing:
+
+1. An entire paragraph is written here, and bigger spacing between list items is desired. This is supported too.
+
+2. Item 2
+
+   1. Blah.
+
+   2. Blah.
+
+1. Item 3
+
+   - Item 3a
+
+   - Item 3b
+
+Paragraph

--- a/testdata/lists.list-uniform-output.md
+++ b/testdata/lists.list-uniform-output.md
@@ -1,0 +1,125 @@
+Tight:
+
+1. First
+2. Second
+3. third
+
+Tight, collapsed line:
+
+1. A paragraph with two lines.
+2. Second
+3. third
+
+Tight, uncollapsed line (notice spaces on end of 1):
+
+1. A paragraph  
+    with two lines.
+2. Second
+3. third
+
+Untight:
+
+1. First
+
+2. Second
+
+3. third
+
+Untight, collapsed line:
+
+1. A paragraph  
+    with two lines
+
+2. Second
+
+3. third
+
+Untight, uncollapsed line:
+
+1. A paragraph  
+    with two lines
+
+2. Second
+
+3. third
+
+Nested tight:
+
+1. tight
+    1. one
+    2. two
+    3. three
+2. tight
+    1. one
+    2. two
+    3. three
+
+Nested tight 3:
+
+1. tight
+    1. one
+        - two
+    2. three
+2. tight
+    1. one
+        - two
+    2. three
+
+Nested:
+
+1. tight
+    1. one
+    2. two
+    3. three
+2. untight
+    1. one
+
+    2. two
+
+    3. three
+3. untight with space
+
+    1. one
+
+    2. two
+
+    3. three
+4. more nested
+    1. baz
+        - inside
+5. more nested
+    - coffee
+        - beer
+
+6. 4
+7. 5
+8. 6
+9. 7
+10. 8
+11. 9
+12. 10
+13. 11
+    - now
+    - I
+14. might
+    1. need
+    2. more
+    3. spaces for nesting
+
+Spacing:
+
+1. An entire paragraph is written here, and bigger spacing between list items is desired. This is supported too.
+
+2. Item 2
+
+    1. Blah.
+
+    2. Blah.
+
+3. Item 3
+
+    - Item 3a
+
+    - Item 3b
+
+Paragraph

--- a/testdata/long-list.list-uniform-input.md
+++ b/testdata/long-list.list-uniform-input.md
@@ -1,0 +1,7 @@
+100. Item 1
+101. Item 2
+     1. Item 2a
+        - Item 2aa
+     2. Item 2b
+102. Item 3
+

--- a/testdata/long-list.list-uniform-output.md
+++ b/testdata/long-list.list-uniform-output.md
@@ -1,0 +1,6 @@
+100. Item 1
+101. Item 2
+     1. Item 2a
+         - Item 2aa
+     2. Item 2b
+102. Item 3

--- a/testdata/reference.list-uniform-input.md
+++ b/testdata/reference.list-uniform-input.md
@@ -1,0 +1,61 @@
+Trying items.
+
+1. Item 1
+2. Item 2
+   1. Item 2a
+      - Item 2aa
+   2. Item 2b
+3. Item 3
+
+### An h3 header
+
+Here's a numbered list:
+
+1. first item
+2. second item
+3. third item
+
+# Nested Lists
+
+### Codeblock within list
+
+- Code block in list does not work reliably
+
+Para
+
+### Blockquote within list
+
+- list1
+
+  > This a quote within a list.
+  >
+  > Still going  
+  > with broken line
+
+### Table within list
+
+- list1
+
+  | Header One | Header Two |
+  |------------|------------|
+  | Item One   | Item Two   |
+
+### Multi-level nested
+
+- Item 1
+
+  Another paragraph inside this list item is indented just like the previous paragraph.
+
+- Item 2
+
+  - Item 2a
+
+    Things go here.
+
+    > This a quote within a list.
+
+    And they stay here.
+
+  - Item 2b
+
+- Item 3

--- a/testdata/reference.list-uniform-output.md
+++ b/testdata/reference.list-uniform-output.md
@@ -1,0 +1,61 @@
+Trying items.
+
+1. Item 1
+2. Item 2
+    1. Item 2a
+        - Item 2aa
+    2. Item 2b
+3. Item 3
+
+### An h3 header
+
+Here's a numbered list:
+
+1. first item
+2. second item
+3. third item
+
+# Nested Lists
+
+### Codeblock within list
+
+- Code block in list does not work reliably
+
+Para
+
+### Blockquote within list
+
+- list1
+
+    > This a quote within a list.
+    >
+    > Still going  
+    > with broken line
+
+### Table within list
+
+- list1
+
+    | Header One | Header Two |
+    |------------|------------|
+    | Item One   | Item Two   |
+
+### Multi-level nested
+
+- Item 1
+
+    Another paragraph inside this list item is indented just like the previous paragraph.
+
+- Item 2
+
+    - Item 2a
+
+        Things go here.
+
+        > This a quote within a list.
+
+        And they stay here.
+
+    - Item 2b
+
+- Item 3

--- a/testdata/things-inside-blocks.list-uniform-input.md
+++ b/testdata/things-inside-blocks.list-uniform-input.md
@@ -1,0 +1,48 @@
+List can have things inside
+
+1. List
+
+2. Subtable
+
+   | table | two |
+   |-------|-----|
+   | table | thr |
+
+3. | table | two |
+   |-------|-----|
+   | table | thr |
+
+4. | table      | two |
+   |------------|-----|
+   | i *tab* le | thr |
+
+5. > blockquote
+   >
+   > will this work? :D
+   >
+   > does not seem so
+   >
+   > > why not
+
+6. # Header
+
+7. Text can have
+
+   # Header
+
+   or
+
+   ### header
+
+   paragraph
+
+8. `code` or rich one like so
+
+   ```C
+   #include <stdio.h>
+   int main() {
+      // printf() displays the string inside quotation
+      printf("Hello, World!");
+      return 0;
+   }
+   ```

--- a/testdata/things-inside-blocks.list-uniform-output.md
+++ b/testdata/things-inside-blocks.list-uniform-output.md
@@ -1,0 +1,48 @@
+List can have things inside
+
+1. List
+
+2. Subtable
+
+    | table | two |
+    |-------|-----|
+    | table | thr |
+
+3. | table | two |
+    |-------|-----|
+    | table | thr |
+
+4. | table      | two |
+    |------------|-----|
+    | i *tab* le | thr |
+
+5. > blockquote
+    >
+    > will this work? :D
+    >
+    > does not seem so
+    >
+    > > why not
+
+6. # Header
+
+7. Text can have
+
+    # Header
+
+    or
+
+    ### header
+
+    paragraph
+
+8. `code` or rich one like so
+
+    ```C
+    #include <stdio.h>
+    int main() {
+       // printf() displays the string inside quotation
+       printf("Hello, World!");
+       return 0;
+    }
+    ```


### PR DESCRIPTION
We currently always indent blocks nested inside list items
so that they're aligned with the list item marker.

    1. foo

       bar

The Commonmark spec allows for, and some tools like pandoc prefer,
to use a more uniform indentation strategy
where everything is indented at least 4 spaces.

    1.  foo

        bar

This change adds a new option, WithListIndentStyle
which allows users to customize this behavior.

There are two styles:

- aligned: this is what we do right now
- uniform: the new indentation strategy closer to pandoc

Note that "uniform" does not go all the way to meet pandoc's style.
Specifically, pandoc indents the initial paragraph as well:

    -   foo

        bar

    -   baz

For now, we're only doing nested items:

    - foo

        bar

    - baz

This is still valid, and it leaves more of the user's input intact.
If there's a strong preference to match pandoc's style,
we can switch to that in a future change.

Testing:
I've added a number of new test cases extracted from list
sections of other tests.
To verify no change in semantics,
I've also added a test that re-parses the new output
and compares it with the output of the old indentation style.

Resolves #69
