### PR TITLE
ci: Run against Go 1.20

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
+    branches: [ '*' ]
 
 jobs:
 
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.17.x", "1.18.x", "1.19.x"]
+        go: ["1.17.x", "1.18.x", "1.19.x", "1.20.x"]
         include:
-        - go: 1.19.x
+        - go: 1.20.x
           os: "ubuntu-latest"
           latest: true
     steps:


### PR DESCRIPTION
Go 1.20 has been released.
Run tests against it.
